### PR TITLE
fix: account for mobile my account links

### DIFF
--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -58,6 +58,7 @@ test("Donations",  {
    * Go to "My Account" page – it's now available as the reader account has been created.
    */
   await page.getByRole("link", { name: "My Account" }).click();
+  await page.waitForURL(/my-account/);
   await expect(page.locator("#newspack_account_email")).toHaveValue(
     emailAddress
   );

--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { randomEmailAddress } from "./utils";
+import { clickMyAccountMenuItem, randomEmailAddress } from "./utils";
 
 const getPageInIframe = (page) =>
   page.frameLocator('iframe[name="newspack_modal_checkout_iframe"]');
@@ -61,8 +61,7 @@ test("Donations",  {
   await expect(page.locator("#newspack_account_email")).toHaveValue(
     emailAddress
   );
-  await page.getByRole("link", { name: "My Subscription" }).click();
-
+  await clickMyAccountMenuItem(page, "Subscription");
   await expect(page.getByText("Visa card ending in 4242")).toBeVisible();
   await expect(
     page.getByRole("cell", { name: "$15.00 / month" }).first()

--- a/tests/reader-registration.spec.ts
+++ b/tests/reader-registration.spec.ts
@@ -59,7 +59,6 @@ test("Register on the site", {
    * Now the user is authenticated via the magic link, they can update their name.
    */
   await page.getByRole("link", { name: "My Account" }).click();
-  await clickMyAccountMenuItem(page, "Account settings");
   await page.getByPlaceholder("Your First Name").click();
   await page.getByPlaceholder("Your First Name").fill("John");
   await page.getByPlaceholder("Your Last Name").click();
@@ -119,7 +118,6 @@ test("Register on the site", {
    * Reader updates their email address.
    */
   const newEmailAddress = randomEmailAddress();
-  await clickMyAccountMenuItem(page, "Account settings");
   await page.locator("#newspack_account_email").fill(newEmailAddress);
   await page.getByRole("button", { name: "Update profile" }).click();
   const expectedNotification = `A verification email has been sent to ${newEmailAddress}. Please verify to complete the change.`;

--- a/tests/reader-registration.spec.ts
+++ b/tests/reader-registration.spec.ts
@@ -59,6 +59,7 @@ test("Register on the site", {
    * Now the user is authenticated via the magic link, they can update their name.
    */
   await page.getByRole("link", { name: "My Account" }).click();
+  await page.waitForURL(/my-account/);
   await page.getByPlaceholder("Your First Name").click();
   await page.getByPlaceholder("Your First Name").fill("John");
   await page.getByPlaceholder("Your Last Name").click();


### PR DESCRIPTION
This PR accounts for mobile my account links as well as subscription link name in donations test.

![Screenshot 2026-02-27 at 17 32 59](https://github.com/user-attachments/assets/1fd7d055-72cd-4645-bdba-6f6e2ac61078)

To test:
```
npm run test:snapshots
```

Note: looks like there is an issue in the plugin repo that can cause the tests to fail, so you may need to also checkout this PR: https://github.com/Automattic/newspack-plugin/pull/4531