### PR TITLE
fix: update homepage-admin test for iframed editor canvas

### DIFF
--- a/tests/homepage-admin.spec.ts
+++ b/tests/homepage-admin.spec.ts
@@ -14,7 +14,7 @@ test("Top featured post and edit homepage", {
       .locator('.wp-block-newspack-blocks-homepage-articles .entry-title a')
       .first()
       .click();
-    await page.waitForURL(url => !/\/$/.test(url.pathname));
+    await page.waitForURL(url => url.pathname !== '/');
 
     // Grab the post title from the post page.
     const featuredPostTitle = (

--- a/tests/homepage-admin.spec.ts
+++ b/tests/homepage-admin.spec.ts
@@ -1,22 +1,37 @@
 import { test, expect } from "@playwright/test";
 
-import {logIn} from "./utils-admin";
+import { logIn } from "./utils-admin";
 
 test("Top featured post and edit homepage", {
         tag: ['@vanilla', '@with-woo'],
     },
-    async ({page}) => {
+    async ({ page }) => {
     await logIn(page);
-    // Go to the homepage and click the featured post.
-    await page.goto('/');
-    await page.locator('.wp-block-newspack-blocks-homepage-articles').first().click();
-    // On the post - grab the title of the post.
-    const featuredPostTitle = await page.locator('h1').textContent();
-    // And go back to the homepage.
-    await page.goto('/');
 
-    // Click "Edit Page" to edit the homepage in the editor.
+    // Go to the homepage and open the first featured post via its title link.
+    await page.goto('/');
+    await page
+      .locator('.wp-block-newspack-blocks-homepage-articles .entry-title a')
+      .first()
+      .click();
+    await page.waitForURL(url => !/\/$/.test(url.pathname));
+
+    // Grab the post title from the post page.
+    const featuredPostTitle = (
+      await page.locator('h1.entry-title').first().textContent()
+    )?.trim() ?? '';
+    expect(featuredPostTitle).not.toBe('');
+
+    // Back to the homepage, then open the page editor via the admin bar.
+    await page.goto('/');
     await page.locator('#wp-admin-bar-edit a').click();
-    // Check that our post title is there in the editor.
-    await expect(page.locator('#editor .wp-block-newspack-blocks-homepage-articles').first().filter({ hasText: featuredPostTitle })).toBeVisible();
+
+    // The block editor canvas is iframed in modern Gutenberg, so look inside it.
+    const editorCanvas = page.frameLocator('iframe[name="editor-canvas"]');
+    await expect(
+      editorCanvas
+        .locator('.wp-block-newspack-blocks-homepage-articles')
+        .first()
+        .filter({ hasText: featuredPostTitle })
+    ).toBeVisible();
 });


### PR DESCRIPTION
## Why

TeamCity build [#150](https://teamcity.a8c.com/build/17809037) failed on `homepage-admin.spec.ts:21`:

```
Locator: locator('#editor .wp-block-newspack-blocks-homepage-articles')
         .first().filter({ hasText: '...1 Suspendisse pulvinar augue ac venenatis...' })
Received: <element(s) not found>
```

The post-editor canvas is rendered inside `<iframe name="editor-canvas">` in modern Gutenberg, so the top-level `page.locator('#editor .wp-block-...')` doesn't reach the block (Playwright locators don't pierce iframe boundaries).

## What

- Look inside the editor canvas via `page.frameLocator('iframe[name="editor-canvas"]')`.
- Click the title link (`.entry-title a`) instead of the block wrapper, so navigation is deterministic.
- Wait for the URL to leave the homepage before reading the post title.
- Read `h1.entry-title` instead of any `h1`, so a stray theme heading can't end up as the comparison text.
- Trim the captured title and assert it isn't empty, surfacing breakage in step 1 rather than letting it cascade into an opaque `toBeVisible` failure.

## Test plan

- [ ] Run on the e2e staging site:  
      `SITE_URL=https://e2e.newspackstaging.com npm test -- homepage-admin.spec.ts`
- [ ] TeamCity green on this branch

## Notes

This PR only fixes `homepage-admin.spec.ts`. The other build #150 failure (`campaigns.spec.ts` 120s timeout) is unrelated and needs the build's `trace.zip` to pin precisely — tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)