### PR TITLE
fix: scope donations Stripe card iframe to the visible frame

### DIFF
--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -5,7 +5,12 @@ const getPageInIframe = (page) =>
   page.frameLocator('iframe[name="newspack_modal_checkout_iframe"]');
 
 const getStripeIframeCard = (page) =>
-  getPageInIframe(page).frameLocator(`[data-payment-method-type="card"] [title="Secure payment input frame"]`);
+  getPageInIframe(page).frameLocator(
+    // Stripe Elements renders an extra aria-hidden "Secure payment input frame"
+    // (the ACH bank-search results frame) alongside the card input frame, so
+    // exclude hidden frames to keep this matching a single element.
+    `[data-payment-method-type="card"] [title="Secure payment input frame"]:not([aria-hidden="true"])`
+  );
 
 const emailAddress = randomEmailAddress();
 


### PR DESCRIPTION
## Summary

`donations.spec.ts` fails because Stripe Elements now renders an **extra `aria-hidden` "Secure payment input frame"** (the ACH bank-search results frame) alongside the card-number frame. The selector `[data-payment-method-type="card"] [title="Secure payment input frame"]` then matches two frames and fails Playwright strict mode.

Fix: exclude hidden frames with `:not([aria-hidden="true"])`.

This is a pre-existing test (independent of the new-coverage work in #26) that the same Stripe change breaks; splitting it out so it can land on its own.

## Test plan

- [x] On WP 7.0 against a local env with Stripe test keys, `donations.spec.ts` completes the donation and passes (previously: strict-mode violation on the card iframe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)