### PR TITLE
fix: run WP DB upgrade around snapshot loads so tests survive core bumps

### DIFF
--- a/tests/utils-admin.ts
+++ b/tests/utils-admin.ts
@@ -59,6 +59,13 @@ export const goToAdminMenu = async (menuItem, submenuItem, page) => {
 export const loadSnapshot = async (page, snapshotName: string) => {
   console.log(`Setting up snapshot: ${snapshotName}`);
 
+  // Clear any pending DB upgrade before we start. If the site's core was
+  // updated without the schema upgrade running (e.g. after a WP major bump),
+  // wp-admin redirects everything to upgrade.php and the snapshots page would
+  // appear empty. Running it before login also avoids logging ourselves out,
+  // since the upgrade invalidates existing sessions.
+  await ensureDatabaseUpgraded(page);
+
   await logIn(page);
   await page.goto('/wp-admin/tools.php?page=newspack-snapshots');
 
@@ -82,11 +89,34 @@ export const loadSnapshot = async (page, snapshotName: string) => {
   await loadLink.waitFor({state: 'visible'});
   await loadLink.click();
 
-  // Add a small wait to ensure dialog handling completes.
-  await page.waitForTimeout(1000);
-  // And wait for the page to load after the snapshot is loaded. We should be logged out and on the login page.
-  await page.waitForSelector('label:text("Username or Email Address")');
+  // Loading the snapshot replaces the DB with the dump captured when the
+  // snapshot was created, which invalidates the current session. Where we land
+  // next depends on the snapshot's age:
+  //  - if its schema matches the running core, WordPress logs us out and we end
+  //    on the login page;
+  //  - if the snapshot predates the current core (older db_version), the DB
+  //    version check in wp-admin/admin.php runs before auth and redirects every
+  //    wp-admin request to upgrade.php instead.
+  // Wait for either outcome to confirm the load (and its redirect chain) is done.
+  await page.waitForURL(/wp-login\.php|upgrade\.php/, {timeout: 60000});
+
+  // Clear any pending DB upgrade the restored dump introduced, so the freshly
+  // loaded site is reachable for the tests that follow.
+  await ensureDatabaseUpgraded(page);
 
   console.log(`Done loading snapshot: ${snapshotName}`);
   return true;
+};
+
+// Run WordPress' database schema upgrade if one is pending.
+//
+// A snapshot is dumped at the core version it was created on, so loading one
+// can roll `db_version` back below the running core's. WordPress then flags a
+// pending upgrade and redirects every wp-admin request to upgrade.php until the
+// upgrade runs. `upgrade.php?step=1` runs it directly: it needs no auth or
+// nonce (it is meant to run mid-upgrade, before login) and is a no-op
+// ("already up to date") when nothing is pending, so it is always safe to call.
+export const ensureDatabaseUpgraded = async (page) => {
+  await page.goto('/wp-admin/upgrade.php?step=1');
+  await page.waitForLoadState('domcontentloaded');
 };


### PR DESCRIPTION
## Problem

After `e2e.newspackstaging.com` was updated to WP 7.0, `npm run test:snapshots` started failing in `loadSnapshot` (`tests/utils-admin.ts`). The snapshot files were intact and WP-CLI listed them fine, so the failure was misleading. Two WP-version-mismatch effects were at play:

1. **Core bumped, DB not upgraded.** When `db_version` lags the running core, `wp-admin/admin.php` runs its DB-version check (and redirects to `upgrade.php`) *before* `auth_redirect()`. So every wp-admin request 302'd to `upgrade.php`; the snapshots admin page rendered empty and the test threw `FATAL: Snapshot "vanilla" not found`. WP-CLI ignores that redirect, which is why the CLI listed the snapshots.
2. **Snapshots carry an older schema.** Each snapshot's DB dump is captured at the core version it was created on. Loading one (created on WP 6.9, `db_version` 60717) rolls the live `db_version` back below the running core, re-arming the same redirect. After the load the browser landed on `upgrade.php`, so the old `waitForSelector('label:text("Username or Email Address")')` (which assumed the login page) timed out.

## Fix

- Add `ensureDatabaseUpgraded()` — navigates to `upgrade.php?step=1`, which runs the schema upgrade directly. It needs no auth or nonce (it's meant to run mid-upgrade) and is a no-op when nothing is pending, so it's always safe to call.
- Call it **before login** (heals a base site whose core was bumped without an upgrade) and **right after loading a snapshot** (heals the schema rollback the dump introduces).
- Replace the brittle post-load login-label wait with `waitForURL(/wp-login\.php|upgrade\.php/)`, which accepts either landing page.

This makes the suite self-healing across WP major bumps without manual intervention on staging.

## Testing

- Reproduced the exact failure locally by lowering the `db_version` baked into the local `vanilla`/`with-woo` snapshot dumps to 60717 on a WP 7.0 env → `loadSnapshot` timed out at the login-label wait, landing on `upgrade.php`.
- With the fix: **10/10** desktop + mobile specs pass locally with those old-schema snapshots.
- **10/10** specs pass against `e2e.newspackstaging.com` (WP 7.0), including donations — the real CI target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)