### PR TITLE
fix: update reader-registration e2e for unified auth modal (newspack 6.43.0)

### DIFF
--- a/tests/reader-registration.spec.ts
+++ b/tests/reader-registration.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from "@playwright/test";
 import {
   addClickIndicator,
   randomString,
-  goToEmailClient,
+  openEmail,
   clickLinkURL,
   randomEmailAddress,
   clickMyAccountMenuItem,
+  goToMyAccount,
 } from "./utils";
 
 const emailAddress = randomEmailAddress();
@@ -16,23 +17,30 @@ test("Register on the site", {
       tag: '@with-woo',
     },
     async ({page}) => {
+  // This exercises the full reader lifecycle (register, OTP sign-in, profile
+  // edit, password set, password sign-in, email change) with three email
+  // round-trips against remote staging, where CI also applies slowMo. The
+  // default 120s is too tight once staging latency varies, so allow more room.
+  test.setTimeout(240000);
   /**
-   * Create a new reader account using the "Sign In" header link.
+   * Create a new reader account using the "Sign In" header link. The auth modal
+   * is a single email-first form: entering an email that isn't associated with
+   * an account registers and signs in the reader, then offers an email
+   * verification step which we dismiss (it is exercised on its own below).
    */
   await page.goto("/");
   await page.getByRole("link", { name: "Sign In" }).click();
-  await page.getByRole("button", { name: "Create an account" }).click();
-  await page.getByPlaceholder("Your email address", { exact: true }).click();
   await page
     .getByPlaceholder("Your email address", { exact: true })
     .fill(emailAddress);
   await page.getByRole("button", { name: "Continue" }).click();
-  await expect(page.getByRole("strong")).toContainText(
-    "Success! Your account was created and you’re signed in."
-  );
-  await page.getByRole("link", { name: "Continue" }).click();
-  await page.getByRole("link", { name: "My Account" }).click();
-  await page.waitForURL(/my-account/);
+  const verifyEmailModal = page.getByRole("heading", {
+    name: "Verify your email",
+  });
+  await expect(verifyEmailModal).toBeVisible();
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(verifyEmailModal).toBeHidden();
+  await goToMyAccount(page);
   await clickMyAccountMenuItem(page, "Sign out");
 
   /**
@@ -51,15 +59,13 @@ test("Register on the site", {
   /**
    * Go to the email client to get the log in link.
    */
-  await goToEmailClient(page, emailAddress);
-  await page.getByText(`Sign in (${emailAddress}`).click();
+  await openEmail(page, "Sign in", emailAddress);
   await clickLinkURL(page, "Continue to");
 
   /**
    * Now the user is authenticated via the magic link, they can update their name.
    */
-  await page.getByRole("link", { name: "My Account" }).click();
-  await page.waitForURL(/my-account/);
+  await goToMyAccount(page);
   await page.getByPlaceholder("Your First Name").click();
   await page.getByPlaceholder("Your First Name").fill("John");
   await page.getByPlaceholder("Your Last Name").click();
@@ -80,8 +86,7 @@ test("Register on the site", {
       "Please check your email inbox for instructions on how to set a new password."
     )
   ).toBeVisible();
-  await goToEmailClient(page, emailAddress);
-  await page.getByText(`Set a new password (${emailAddress}`).click();
+  await openEmail(page, "Set a new password", emailAddress);
   await clickLinkURL(page, "Set password");
 
   const password = randomString(14);
@@ -112,8 +117,7 @@ test("Register on the site", {
     "Success! You’re signed in."
   );
   await page.getByRole("link", { name: "Continue" }).click();
-  await page.getByRole("link", { name: "My Account" }).click();
-  await page.waitForURL(/my-account/);
+  await goToMyAccount(page);
 
   /**
    * Reader updates their email address.
@@ -123,8 +127,7 @@ test("Register on the site", {
   await page.getByRole("button", { name: "Update profile" }).click();
   const expectedNotification = `A verification email has been sent to ${newEmailAddress}. Please verify to complete the change.`;
   await expect(page.getByText(expectedNotification)).toBeVisible();
-  await goToEmailClient(page, newEmailAddress);
-  await page.getByText(`Confirm email change (${newEmailAddress})`).click();
+  await openEmail(page, "Confirm email change", newEmailAddress);
   await clickLinkURL(page, "Confirm email change");
   await expect(
     page.getByText("Your email address has been successfully updated.")

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,3 +1,5 @@
+import { expect } from "@playwright/test";
+
 export const randomString = (length = 8) =>
   Math.random()
     .toString(36)
@@ -5,9 +7,27 @@ export const randomString = (length = 8) =>
 
 export const randomEmailAddress = () => `test-${randomString()}@example.com`;
 
-export const goToEmailClient = async (page, cachebust = "") => {
-  await page.waitForTimeout(1000); // Wait a moment to let the server save the email.
-  await page.goto(`/_email?cachebust=${cachebust}`);
+// Open an email in the dev "Email Sendbox" (/_email) by its subject + recipient.
+// Emails are saved asynchronously and the sendbox is a static page, so we reload
+// until the message shows up instead of trusting a single load (otherwise a
+// message that arrives after the page render is never seen).
+export const openEmail = async (page, subjectPrefix, emailAddress) => {
+  const emailLink = page.getByText(`${subjectPrefix} (${emailAddress}`);
+  await expect(async () => {
+    await page.goto(`/_email?cachebust=${emailAddress}-${Date.now()}`);
+    await expect(emailLink).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 30000 });
+  await emailLink.click();
+};
+
+// Navigate to the reader's My Account page. We go directly rather than clicking
+// the header link: that link is collapsed behind the nav toggle on mobile, and
+// auth events (registration, magic-link or password sign-in) trigger an
+// asynchronous reload that can swallow the click. A direct navigation is
+// reliable on every viewport.
+export const goToMyAccount = async (page) => {
+  await page.goto("/my-account/");
+  await page.waitForURL(/my-account/);
 };
 
 export const clickLinkURL = async (page, linkText) => {


### PR DESCRIPTION
## Why

The nightly `reader-registration` test has failed since staging picked up **newspack@6.43.0**. That release shipped [Automattic/newspack-workspace#135](https://github.com/Automattic/newspack-workspace/pull/135) ([NPPM-2835](https://linear.app/a8c/issue/NPPM-2835)), which:

- replaced the dual-state auth modal (separate "Create an account" / "Sign into existing account" toggles) with a single email-first **"Sign in or register"** form, and
- added a post-registration **"Verify your email"** step.

The test timed out at the old `Create an account` button, which no longer exists.

## Changes

- **Registration head rewritten** to the unified flow: enter email → Continue → dismiss the new "Verify your email" modal (the OTP/verification path is still exercised later in the test).
- **`openEmail()`** replaces the one-shot `goToEmailClient`. The `/_email` sendbox is a static page and emails are saved asynchronously, so it reloads until the message appears instead of trusting a single load.
- **`goToMyAccount()`** navigates directly to `/my-account/` rather than clicking the header link, which is collapsed behind the nav toggle on mobile and can be swallowed by the post-auth reload.
- **`test.setTimeout(240000)`** for this test: the full reader lifecycle (three email round-trips) against remote staging plus CI `slowMo` overruns the default 120s when staging latency spikes (a single `goto("/")` was observed taking 43s).

## Testing

Ran against `https://e2e.newspackstaging.com` (no snapshot reload, current with-woo state):

- **With Woo in Desktop Chrome** – green across 5 runs.
- **With Woo in Mobile Chrome** – green across 3 of 4 runs (one early staging-latency flake, did not recur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)