### PR TITLE
fix: match donation summary by amount + cadence, not full label

### DIFF
--- a/tests/donations.spec.ts
+++ b/tests/donations.spec.ts
@@ -25,9 +25,10 @@ test("Donations",  {
   await page.goto("/support-our-publication/");
   await page.getByRole("button", { name: "Donate Now" }).click();
   await expect(
-    getPageInIframe(page).locator(
-      'strong:has-text("Donate: $15.00 / month")'
-    )
+    // Match just the amount and cadence: the summary's label prefix has varied
+    // across Newspack versions (e.g. "Donate:" then "Donate: Monthly:"), but the
+    // "$15.00 / month" part is stable and is the bit worth asserting.
+    getPageInIframe(page).locator('strong:has-text("$15.00 / month")')
   ).toBeVisible();
   await getPageInIframe(page).getByLabel("Email address *").fill(emailAddress);
   await getPageInIframe(page).getByLabel("First name *").fill("John");


### PR DESCRIPTION
## What

Loosen the donation-summary assertion in `donations.spec.ts` from the full label to just the amount + cadence.

```diff
-'strong:has-text("Donate: $15.00 / month")'
+'strong:has-text("$15.00 / month")'
```

## Why

The nightly (and the build triggered by #34) failed on `Donations @with-woo`, timing out 20s waiting for `strong:has-text("Donate: $15.00 / month")`.

The checkout is healthy — the modal opens and renders the summary — but a Newspack update changed the summary label to insert the cadence:

> `Donate: Monthly: $15.00 / month`

So `"Donate: $15.00 / month"` is no longer a substring and `has-text` never matches. This label prefix has churned before (#21 changed it once already), whereas `$15.00 / month` is stable and is the part actually worth asserting.

This is unrelated to the earlier snapshot-corruption incident — that build merely triggered this run.

## How to test

Verified end to end against `e2e.newspackstaging.com` (with-woo loaded):

```
$ npx playwright test tests/donations.spec.ts --project="With Woo in Desktop Chrome"
  ✓  1 Donations @with-woo (22.9s)
  1 passed
```

The full flow — summary, billing details, Stripe test card, "Transaction successful" — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)